### PR TITLE
Build PDF

### DIFF
--- a/.github/workflows/pdf_build.yml
+++ b/.github/workflows/pdf_build.yml
@@ -1,0 +1,41 @@
+# Copyright (c) 2024 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+name: viss_build
+
+on:
+  push:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+      group: ${{ github.ref }}-${{ github.workflow }}
+      cancel-in-progress: true
+
+jobs:
+  build-pdf:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Building
+      run: |
+        sudo apt-get install htmldoc -y
+        htmldoc --webpage -f VISSv2_Core.pdf spec/VISSv2_Core.html
+        htmldoc --webpage -f VISSv2_Transport.pdf spec/VISSv2_Transport.html
+
+    - name: "Upload PDFs"
+      uses: actions/upload-artifact@v4
+      with:
+        name: viss-pdfs
+        path: '*.pdf'
+


### PR DESCRIPTION
This is a workflow that generates PDF files whenever you create a Pull Request or merge something. 

A possible usage could be for releases:

- Take generated PDFs from last build on main, or trigger a build on main or tag if they have expired
- Create a release
- Upload the PDFs to the release (in addition to the source html that gets uploaded automatically)

**Notes**

- The PDFs are a bit ugly, if we consider the PDFs as important we maybe should invest time in making them prettier
- The license header could be discussed and adapted to whatever license we want to have for this repo, if any
- I do not think build is triggered on initial pull request. see https://github.com/erikbosch/vehicle-information-service-specification/actions/runs/8418338852 for an example of result
