### PR TITLE
Add action for creating draft release

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -1,0 +1,44 @@
+name: Create Draft Release
+
+on:
+  push:
+   tags:
+     - "*.*"
+
+# Needed if GITHUB_TOKEN by default do not have right to create release
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  call_pdf_build:
+    uses: ./.github/workflows/pdf_build.yml
+
+  create_release:
+    runs-on: ubuntu-latest
+    needs:
+      [
+        call_pdf_build
+      ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build-artifacts
+          merge-multiple: true
+      - name: Display structure of downloaded files
+        run: |
+             ls -R build-artifacts
+
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: VISS ${{ github.ref_name }}
+          fail_on_unmatched_files: true
+          files: |
+            build-artifacts/*


### PR DESCRIPTION
This is inspired by VSS workflow https://github.com/COVESA/vehicle_signal_specification/blob/master/.github/workflows/create_draft_release.yml and Kuksa workflow https://github.com/eclipse-kuksa/kuksa-databroker/blob/main/.github/workflows/create_draft_release.yml

It intends to simplify https://github.com/COVESA/vehicle-information-service-specification/wiki/VISS-Governanance-and-Release-Process

If merged - a new draft release will be automatically created if you push a tag to the repo.
Content will be like this example (in my own fork): https://github.com/erikbosch/vehicle-information-service-specification/releases/tag/v3.2 but a maintainer must visit the release and publish it.




